### PR TITLE
Fix undefined logger error in _scan_dbus_service

### DIFF
--- a/dbus_mqtt.py
+++ b/dbus_mqtt.py
@@ -216,9 +216,9 @@ class DbusMqtt(MqttGObjectBridge):
 		except dbus.exceptions.DBusException, e:
 			if e.get_dbus_name() == 'org.freedesktop.DBus.Error.ServiceUnknown' or \
 				e.get_dbus_name() == 'org.freedesktop.DBus.Error.Disconnected':
-				logger.info("[Scanning] Service disappeared while being scanned: %s", service)
+				logging.info("[Scanning] Service disappeared while being scanned: %s", service)
 			elif e.get_dbus_name() == 'org.freedesktop.DBus.Error.NoReply':
-				logger.info("[Scanning] No response from service during scan: %s", service)
+				logging.info("[Scanning] No response from service during scan: %s", service)
 			else:
 				raise
 


### PR DESCRIPTION
The wrong logger variable was used in the _scan_dbus_service method, did only occur when a DBusException was raised. 